### PR TITLE
Fix incorrect form builder layout example in documentation

### DIFF
--- a/docs/cms/form-builder-get-started.md
+++ b/docs/cms/form-builder-get-started.md
@@ -111,7 +111,7 @@ use Botble\Base\Forms\Fields\TextField;
 use Botble\Base\Forms\Fields\TextareaField;
 
 $this
-    ->columns(3) // Use 3 columns layout
+    ->columns(12) // Use 12 columns layout
     ->add('field1', TextField::class, TextFieldOption::make()->colspan(4))
     ->add('field2', TextField::class, TextFieldOption::make()->colspan(4))
     ->add('field3', TextField::class, TextFieldOption::make()->colspan(4));


### PR DESCRIPTION
The documentation previously used ->columns(3) in the form builder example,
which is inconsistent with the current 12-column grid system.

This PR updates the example to use ->columns(12) for accuracy and clarity.

Changes:

- Updated form builder example from ->columns(3) to ->columns(12) in documentation.

- Ensures developers follow the correct grid-based layout approach when using colspan().